### PR TITLE
disable buffering in lighttpd

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -9,6 +9,9 @@ accesslog.filename = "/var/log/lighttpd/access.log"
 
 server.port = 80
 server.document-root = "/root/www"
+server.stream-request-body = 2
+server.stream-response-body = 2
+ssl.read-ahead = "disable"
 
 $HTTP["url"] =~ "^/api" {
     setenv.add-response-header = (

--- a/httpd.conf.template
+++ b/httpd.conf.template
@@ -9,6 +9,9 @@ accesslog.filename = "/var/log/lighttpd/access.log"
 
 server.port = 80
 server.document-root = "/root/www"
+server.stream-request-body = 2
+server.stream-response-body = 2
+ssl.read-ahead = "disable"
 
 $HTTP["url"] =~ "^/api" {
     setenv.add-response-header = (


### PR DESCRIPTION
Disable request buffering and response buffering in lighttpd because it's slowing filebrowser down on the embassy, since the sd card's write speeds are slow. Disabling lighttpd's buffering, together with disabling nginx's analogous buffering, results in a considerable performance speedup in filebrowser uploads and downloads.

Request buffering:
https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_stream-request-bodyDetails
Note that the docs recommend additionally setting `ssl.read-ahead = "disable"` on embedded systems.

Response buffering:
https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_stream-response-bodyDetails

I set both to 2 since that results in the least amount of buffering to disk.

Fixes https://github.com/Start9Labs/filebrowser-wrapper/issues/6