### PR TITLE
Update to run on x86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ image.tar
 filebrowser.s9pk
 scripts/embassy.js
 scripts/generated/*
+.vscode
+docker-images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:alpine3.13 AS builder
+FROM golang:alpine3.13 AS builder
 
 RUN apk update
 RUN apk add --no-cache git
@@ -12,7 +12,7 @@ RUN go mod download
 RUN cd http && rice embed-go
 RUN go build
 
-FROM arm64v8/alpine:3.13 AS runner
+FROM alpine:latest AS runner
 
 RUN apk update
 RUN apk add --no-cache tini

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,37 @@
-VERSION_TAG := $(shell git --git-dir=filebrowser/.git describe --abbrev=0)
-VERSION := $(VERSION_TAG:v%=%)
-EMVER := $(shell yq e ".version" manifest.yaml)
+PKG_VERSION := $(shell yq e ".version" manifest.yaml)
+PKG_ID := $(shell yq e ".id" manifest.yaml)
 FILEBROWSER_SRC := $(shell find filebrowser -name '*.go') $(shell find filebrowser -name 'go.*')
 FILEBROWSER_FRONTEND_SRC := $(shell find filebrowser/frontend -type d \( -path filebrowser/frontend/dist -o -path filebrowser/frontend/node_modules \) -prune -o -name '*' -print)
-FILEBROWSER_GIT_REF := $(shell cat .git/modules/filebrowser/HEAD)
-FILEBROWSER_GIT_FILE := $(addprefix .git/modules/filebrowser/,$(if $(filter ref:%,$(FILEBROWSER_GIT_REF)),$(lastword $(FILEBROWSER_GIT_REF)),HEAD))
-TS_FILES := $(shell find ./ -name \*.ts)
 
+# delete the target of a rule if it has changed and its recipe exits with a nonzero exit status
 .DELETE_ON_ERROR:
 
 all: verify
 
-install: filebrowser.s9pk
-	embassy-cli package install filebrowser.s9pk
+# assumes /etc/embassy/config.yaml exists on local system with `host: "http://embassy-server-name.local"` configured
+install:
+	embassy-cli package install $(PKG_ID).s9pk
 
-filebrowser.s9pk: manifest.yaml image.tar instructions.md LICENSE icon.png $(ASSET_PATHS) scripts/embassy.js
+verify: $(PKG_ID).s9pk
+	embassy-sdk verify s9pk $(PKG_ID).s9pk
+
+clean:
+	rm -rf docker-images
+	rm -f  $(PKG_ID).s9pk
+	rm -f image.tar
+	rm -f scripts/*.js
+
+$(PKG_ID).s9pk: manifest.yaml instructions.md LICENSE icon.png scripts/embassy.js docker-images/aarch64.tar docker-images/x86_64.tar
+	if ! [ -z "$(ARCH)" ]; then cp docker-images/$(ARCH).tar image.tar; fi
 	embassy-sdk pack
-	
-verify: filebrowser.s9pk
-	embassy-sdk verify s9pk filebrowser.s9pk
 
-image.tar: Dockerfile docker_entrypoint.sh health-check.sh httpd.conf $(FILEBROWSER_SRC) filebrowser/frontend/dist
-	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/filebrowser/main:${EMVER} --platform=linux/arm64/v8 -o type=docker,dest=image.tar .
+docker-images/aarch64.tar: Dockerfile docker_entrypoint.sh httpd.conf $(FILEBROWSER_SRC) filebrowser/frontend/dist
+	mkdir -p docker-images
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/$(PKG_ID)/main:${PKG_VERSION} --platform=linux/arm64/v8 -o type=docker,dest=docker-images/aarch64.tar .
+
+docker-images/x86_64.tar: Dockerfile docker_entrypoint.sh httpd.conf $(FILEBROWSER_SRC) filebrowser/frontend/dist
+	mkdir -p docker-images
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/$(PKG_ID)/main:${PKG_VERSION} --platform=linux/amd64 -o type=docker,dest=docker-images/x86_64.tar .
 
 httpd.conf: manifest.yaml httpd.conf.template
 	tiny-tmpl manifest.yaml < httpd.conf.template > httpd.conf
@@ -36,8 +46,7 @@ manifest.yaml: $(FILEBROWSER_GIT_FILE)
 	yq eval -i ".version = \"$(VERSION)\"" manifest.yaml
 	yq eval -i ".release-notes = \"https://github.com/filebrowser/filebrowser/releases/tag/$(VERSION_TAG)\"" manifest.yaml
 
-
-scripts/embassy.js: $(TS_FILES) 
+scripts/embassy.js: $(TS_FILES) scripts/generated/manifest.ts
 	deno bundle scripts/embassy.ts scripts/embassy.js
 
 scripts/generated/manifest.ts: manifest.yaml scripts/generateManifest.ts

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ FILEBROWSER_FRONTEND_SRC := $(shell find filebrowser/frontend -type d \( -path f
 all: verify
 
 # assumes /etc/embassy/config.yaml exists on local system with `host: "http://embassy-server-name.local"` configured
-install:
+install: $(PKG_ID).s9pk
 	embassy-cli package install $(PKG_ID).s9pk
 
 verify: $(PKG_ID).s9pk
@@ -50,4 +50,5 @@ scripts/embassy.js: $(TS_FILES) scripts/generated/manifest.ts
 	deno bundle scripts/embassy.ts scripts/embassy.js
 
 scripts/generated/manifest.ts: manifest.yaml scripts/generateManifest.ts
+	mkdir -p scripts/generated
 	deno run --allow-write --allow-read scripts/generateManifest.ts

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-# Wrapper for File Browser
+# Wrapper for filebrowser
+
+[File Browser](https://github.com/filebrowser/filebrowser) provides a simple file managing interface which can be used to upload, download, organize, edit, and share your files. It allows the creation of multiple users and each user can have their own directory. This repository creates the `s9pk` package that is installed to run `filebrowser` on [embassyOS](https://github.com/Start9Labs/embassy-os/).
 
 ## Dependencies
+
+Install the following system dependencies to build this project by following the instructions in the provided links. You can also find detailed steps to setup your environment in the service packaging [documentation](https://github.com/Start9Labs/service-pipeline#development-environment).
 
 - [docker](https://docs.docker.com/get-docker)
 - [docker-buildx](https://docs.docker.com/buildx/working-with-buildx/)
 - [yq](https://mikefarah.gitbook.io/yq)
 - [tiny-tmpl](https://github.com/Start9Labs/templating-engine-rs.git)
 - [npm](https://www.npmjs.com/get-npm)
-- [appmgr](https://github.com/Start9Labs/embassy-os/tree/master/appmgr)
+- [make](https://www.gnu.org/software/make/)
+- [embassy-sdk](https://github.com/Start9Labs/embassy-os/tree/master/backend)
 - [deno](https://deno.land/#installation)
 
 ## Cloning
+
+Clone the File Browser Wrapper locally. Note the submodule link to the original project.
+
 ```
 git clone git@github.com:Start9Labs/filebrowser-wrapper.git
 cd filebrowser-wrapper
@@ -19,11 +27,36 @@ git submodule update --init
 
 ## Building
 
+To build the `filebrowser` package, run the following command:
+
 ```
 make
 ```
 
-## Installing (on Embassy)
+## Installing (on embassyOS)
+
+Run the following commands to install:
+
+> :information_source: Change embassy-server-name.local to your Embassy address
+
 ```
-embassy-cli package install filebrowser.s9pk
+embassy-cli auth login
+# Enter your embassy password
+embassy-cli --host https://embassy-server-name.local package install filebrowser.s9pk
 ```
+
+If you already have your `embassy-cli` config file setup with a default `host`,
+you can install simply by running:
+
+```
+make install
+```
+
+> **Tip:** You can also install the filebrowser.s9pk using **Sideload Service** under
+the **Embassy > Settings** section.
+
+### Verify Install
+
+Go to your Embassy Services page, select **File Browser**, configure and start the service. Then, verify its interfaces are accessible.
+
+**Done!** 

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -67,7 +67,7 @@ health-check.sh &
 
 lighttpd -f /etc/lighttpd/httpd.conf
 
-tini -sp SIGTERM -- filebrowser --disable-exec=true &
+tini -p SIGTERM -- filebrowser --disable-exec=true &
 filebrowser_process=$1
 
 trap _term SIGTERM

--- a/httpd.conf
+++ b/httpd.conf
@@ -21,7 +21,7 @@ $HTTP["url"] =~ "^/api" {
 } else {
     setenv.add-response-header = (
         "X-Consulate-App-ID" => "filebrowser",
-        "X-Consulate-App-Version" => "2.22.4"
+        "X-Consulate-App-Version" => "2.22.4.1"
     )
 }
 $HTTP["url"] =~ "^/api/login" {

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,7 @@
 id: filebrowser
 title: "File Browser"
-version: 2.22.4
-release-notes: |-
-  https://github.com/filebrowser/filebrowser/releases/tag/v2.22.4
+version: 2.22.4.1
+release-notes: Update to run on x86_64 architecture
 license: apache
 wrapper-repo: "https://github.com/Start9Labs/filebrowser-wrapper"
 upstream-repo: "https://github.com/filebrowser/filebrowser"

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/embassyd_sdk@v0.3.1.1.1/mod.ts";
+export * from "https://deno.land/x/embassyd_sdk@v0.3.1.1.4/mod.ts";

--- a/scripts/services/health.ts
+++ b/scripts/services/health.ts
@@ -86,7 +86,7 @@ const healthWeb: T.ExpectedExports.health[""] = async (effects, duration) => {
   if (fetchWeb.status === 200) {
     return ok;
   }
-  return error(`Fetching the website returned ${fetchWeb.status}`);
+  return error(`The File Browser UI is unreachable`);
 };
 
 /** These are the health checks in the manifest */


### PR DESCRIPTION
Proof:
```
root@embassy-neon-skate:/home/start9# docker exec -it filebrowser.embassy /bin/sh
~ # uname -a
Linux filebrowser.embassy 5.10.92-v8+ #1514 SMP PREEMPT Mon Jan 17 17:39:38 GMT 2022 x86_64 GNU/Linux
```