### PR TITLE
chore: bump File Browser to 2.63.3 and start-sdk to 1.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,3 @@
-## How the upstream version is pulled
-- dockerTag in `startos/manifest/index.ts`: `filebrowser/filebrowser:v<version>`
+# CLAUDE.md
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the doc map and contribution workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,36 @@
 # Contributing
 
-## Building and Development
+This repo packages [File Browser](https://github.com/filebrowser/filebrowser) for StartOS.
 
-See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for complete environment setup and build instructions.
+## Documentation — keep it in sync
 
-### Quick Start
+- **`README.md`** — what this package is and how it's built (image, volumes, interfaces). For developers and AI assistants.
+- **`instructions.md`** — the user-facing instructions packed into the `.s9pk` and shown on the **Instructions** tab in StartOS, for the person running the service.
+- **`CONTRIBUTING.md`** — this file.
+- **`CLAUDE.md`** — operating rules for AI developers working in this repo.
+
+**Any code change that warrants it must update `README.md` and `instructions.md` in the same change** — a new or renamed action, an added or removed volume / port / interface / dependency, a changed default, a new limitation, any altered user-visible behavior. Don't defer: a package that ships with a stale README or stale instructions is not done, even if the code is perfect. Content rules live in the packaging guide: [Writing READMEs](https://docs.start9.com/packaging/writing-readmes.html) and [Writing Service Instructions](https://docs.start9.com/packaging/writing-instructions.html).
+
+## Building
+
+See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for environment setup, then:
 
 ```bash
-# Install dependencies
-npm ci
-
-# Build universal package
-make
+npm ci    # install dependencies
+make      # build the universal .s9pk
 ```
 
-## How to Contribute
+## Updating the upstream version
 
-1. Fork the repository and create a branch from `master`
-2. Make your changes
-3. Open a pull request to `master`
+File Browser is pulled in as the upstream `filebrowser/filebrowser` Docker Hub image. To track a new upstream release:
+
+1. Bump `dockerTag` in `startos/manifest/index.ts` to `filebrowser/filebrowser:v<new version>`.
+2. Update `version` and `releaseNotes` in the file under `startos/versions/`, renaming it to the new version string. A *new* version file is only needed when the bump carries an `up`/`down` migration, or when you want the old release notes preserved in git history — see [Versions](https://docs.start9.com/packaging/versions.html).
+3. Rebuild (`make`), sideload the `.s9pk`, and confirm it starts.
+4. Review `README.md` and `instructions.md` for anything the bump changed.
+
+## How to contribute
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes — including the doc updates above.
+3. Open a pull request to `master`.

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,29 @@
+# File Browser
+
+## Documentation
+
+- [File Browser documentation](https://github.com/filebrowser/filebrowser/tree/master/www/docs) — upstream guide covering features, permissions, sharing, and configuration.
+
+## What you get on StartOS
+
+- A **Web UI** for browsing, uploading, downloading, editing, and sharing files stored on your server.
+- A persistent file storage volume mounted at `/srv` inside the container — this is the root that File Browser browses.
+- Multi-user support with per-user permissions and shareable links, all managed through the Web UI.
+
+## Getting set up
+
+File Browser posts a critical task after install. You can't start the service until it is done.
+
+1. Run the **Set Admin Password** task. A username (`admin`) and a randomly generated password are shown once — copy and save the password before dismissing. If you lose it, run the **Set Admin Password** action again later to generate a new one.
+2. Start File Browser and open the **Web UI**. Log in with `admin` and the password from the previous step.
+
+## Using File Browser
+
+### Web UI
+
+The Web UI is where all day-to-day file management happens — upload, download, rename, move, delete, preview, edit, and share files. Create additional user accounts and assign permissions from the settings menu inside the UI.
+
+### Actions
+
+- **Set Admin Password** — generates a new random password for the `admin` user. Use it to rotate credentials or recover from a lost password. File Browser must be stopped to run this action.
+- **Set Session Timeout** — sets how many hours a logged-in browser session lasts before it is automatically terminated. Defaults to 12 hours; minimum is 1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "filebrowser-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3"
+        "@start9labs/start-sdk": "1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
-      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
+      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -71,12 +71,12 @@
         "@noble/hashes": "^1.8.0",
         "@types/ini": "^4.1.1",
         "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
+        "fast-xml-parser": "~5.7.0",
         "ini": "^5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       }
     },
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -127,13 +127,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -142,8 +143,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -230,9 +231,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -246,9 +247,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -306,10 +307,25 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -326,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3"
+    "@start9labs/start-sdk": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -16,7 +16,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.2',
+        dockerTag: 'filebrowser/filebrowser:v2.63.3',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -10,7 +10,6 @@ export const manifest = setupManifest({
   upstreamRepo: 'https://github.com/filebrowser/filebrowser',
   marketingUrl: 'https://filebrowser.org/',
   donationUrl: null,
-  docsUrls: ['https://github.com/filebrowser/filebrowser/tree/master/www/docs'],
   description: { short, long },
   volumes: ['data', 'database', 'config', 'main'], // main only needed for 0351 migration
   images: {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_2_63_2_1 } from './v2.63.2.1'
+import { v_2_63_3_0 } from './v2.63.3.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2_63_2_1,
+  current: v_2_63_3_0,
   other: [],
 })

--- a/startos/versions/v2.63.3.0.ts
+++ b/startos/versions/v2.63.3.0.ts
@@ -3,14 +3,69 @@ import { execFile } from 'child_process'
 import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
-export const v_2_63_2_1 = VersionInfo.of({
-  version: '2.63.2:1',
+export const v_2_63_3_0 = VersionInfo.of({
+  version: '2.63.3:0',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.3.3)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.3.3)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.3.3)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.3.3)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.3.3)',
+    en_US: `**Bumps**
+
+- File Browser → 2.63.3
+
+**Fixes**
+
+- Conflict modal and resume-transfer option in the upload flow
+- Arrow keys now seek video in the preview instead of switching files
+
+**Internal**
+
+- start-sdk → 1.5.0`,
+    es_ES: `**Cambios de versión**
+
+- File Browser → 2.63.3
+
+**Correcciones**
+
+- Modal de conflicto y opción de reanudar transferencia en la carga
+- Las teclas de flecha ahora avanzan el vídeo en la vista previa en lugar de cambiar de archivo
+
+**Interno**
+
+- start-sdk → 1.5.0`,
+    de_DE: `**Aktualisierungen**
+
+- File Browser → 2.63.3
+
+**Fehlerbehebungen**
+
+- Konflikt-Dialog und Option zum Fortsetzen der Übertragung beim Hochladen
+- Pfeiltasten spulen in der Videovorschau, statt zwischen Dateien zu wechseln
+
+**Intern**
+
+- start-sdk → 1.5.0`,
+    pl_PL: `**Aktualizacje**
+
+- File Browser → 2.63.3
+
+**Poprawki**
+
+- Okno konfliktu i opcja wznowienia transferu w procesie wysyłania
+- Klawisze strzałek przewijają wideo w podglądzie zamiast przełączać pliki
+
+**Wewnętrzne**
+
+- start-sdk → 1.5.0`,
+    fr_FR: `**Mises à niveau**
+
+- File Browser → 2.63.3
+
+**Corrections**
+
+- Fenêtre de conflit et option de reprise de transfert lors de l'envoi
+- Les touches fléchées font défiler la vidéo dans l'aperçu au lieu de changer de fichier
+
+**Interne**
+
+- start-sdk → 1.5.0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Upstream **File Browser** patch bump: `2.63.2` → `2.63.3` (fixes for the conflict modal / resume-transfer flow in uploads, arrow-key seek in video preview, plus dependency updates — see [upstream release notes](https://github.com/filebrowser/filebrowser/releases/tag/v2.63.3)).
- **start-sdk** bump: `1.3.3` → `1.5.0`. No code changes required — `tsc --noEmit` is clean and `make` produces `.s9pk` for both `x86_64` and `aarch64`.
- `npm update` to pick up the latest published transitive deps.

Package version: `2.63.2:1` → `2.63.3:0`. No new migration is needed for the patch bump, so `v2.63.2.1.ts` was **renamed in place** to `v2.63.3.0.ts` per the version-file convention (`other: []`); the existing migration body in that file continues to bring users from the older data layout up to current.

README review: no changes — the README does not reference upstream patch versions, and the 2.63.3 fixes (conflict modal, video preview keys) are not user-visible at the StartOS layer (no action, port, volume, or interface affected).

## Test plan

- [x] `npm install` — clean
- [x] `npm update` — picked up latest transitive deps
- [x] `npx tsc --noEmit` — clean
- [x] `make x86_64` — builds `filebrowser_x86_64.s9pk` (15M)
- [x] `make aarch64` — builds `filebrowser_aarch64.s9pk` (14M)