### PR TITLE
chore: bump File Browser 2.63.3 and start-sdk 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "filebrowser-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3"
+        "@start9labs/start-sdk": "1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
-      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
+      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -71,12 +71,12 @@
         "@noble/hashes": "^1.8.0",
         "@types/ini": "^4.1.1",
         "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
+        "fast-xml-parser": "~5.7.0",
         "ini": "^5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       }
     },
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -127,13 +127,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -142,8 +143,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -230,9 +231,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -246,9 +247,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -306,10 +307,25 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -326,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3"
+    "@start9labs/start-sdk": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -16,7 +16,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.2',
+        dockerTag: 'filebrowser/filebrowser:v2.63.3',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_2_63_2_1 } from './v2.63.2.1'
+import { v_2_63_3_0 } from './v2.63.3.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2_63_2_1,
+  current: v_2_63_3_0,
   other: [],
 })

--- a/startos/versions/v2.63.3.0.ts
+++ b/startos/versions/v2.63.3.0.ts
@@ -3,14 +3,29 @@ import { execFile } from 'child_process'
 import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
-export const v_2_63_2_1 = VersionInfo.of({
-  version: '2.63.2:1',
+export const v_2_63_3_0 = VersionInfo.of({
+  version: '2.63.3:0',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.3.3)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.3.3)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.3.3)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.3.3)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.3.3)',
+    en_US: `**Bumps**
+
+- File Browser → 2.63.3
+- start-sdk → 1.5.0`,
+    es_ES: `**Cambios de versión**
+
+- File Browser → 2.63.3
+- start-sdk → 1.5.0`,
+    de_DE: `**Versionsanhebungen**
+
+- File Browser → 2.63.3
+- start-sdk → 1.5.0`,
+    pl_PL: `**Aktualizacje wersji**
+
+- File Browser → 2.63.3
+- start-sdk → 1.5.0`,
+    fr_FR: `**Mises à jour de version**
+
+- File Browser → 2.63.3
+- start-sdk → 1.5.0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps File Browser **2.63.2 → 2.63.3** (upstream patch — release notes [here](https://github.com/filebrowser/filebrowser/releases/tag/v2.63.3))
- Bumps `@start9labs/start-sdk` **1.3.3 → 1.5.0**
- `npm update` refreshes lock-file transitives

## Upstream changes (2.63.2 → 2.63.3)

Patch release — no breaking changes, no behavior change for anything the StartOS package exposes.

- `fix: Fix conflict modal and add a resume transfer option` (#5884)
- `fix(preview): let arrow keys seek video instead of switching files` (#5895)
- `fix: correct environment variable in compose.yaml` (#5910) — affects upstream compose example only
- Translation pulls and dependency refreshes (marked → v18, pnpm/action-setup → v6, etc.)

None of this touches the API surface or storage layout, so volumes (`data`, `database`, `config`), the `8080` web interface, and both actions (`reset-admin-user`, `set-expiration`) keep working unchanged. README is still accurate; no edits.

## SDK 1.3.3 → 1.5.0

Drop-in — typecheck passes with no code changes. (Other packages bumping the same way: spliit-startos#1, home-assistant-startos#4, bitcoin-core-startos#206 etc.)

## Version file

`startos/versions/v2.63.2.1.ts` is **renamed in place** to `v2.63.3.0.ts` (per the in-repo convention from 8a84a67, "Clean up versions/ shape"). The legacy-main-volume migration body is preserved so anyone still upgrading from pre-2.63.2:1 follows the same path; it's idempotent (`if (configYaml)` gate) so a no-op for everyone already on 2.63.2:1. `other: []` is kept.

Release notes localized in en/es/de/pl/fr with the standard **Bumps** header.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `make` packs both arches:
  - `filebrowser_x86_64.s9pk` — 15M
  - `filebrowser_aarch64.s9pk` — 14M
- [ ] Sideload on StartOS and confirm the package starts, the web UI loads, and existing user accounts/files survive the upgrade