### PR TITLE
chore: bump start-sdk 1.5.1 → 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "filebrowser-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.2"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -342,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1"
+    "@start9labs/start-sdk": "1.5.2"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.3',
+        dockerTag: 'filebrowser/filebrowser:v2.63.4',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_2_63_3_0 } from './v2.63.3.0'
+import { v_2_63_4_0 } from './v2.63.4.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2_63_3_0,
+  current: v_2_63_4_0,
   other: [],
 })

--- a/startos/versions/v2.63.3.0.ts
+++ b/startos/versions/v2.63.3.0.ts
@@ -17,7 +17,7 @@ export const v_2_63_3_0 = VersionInfo.of({
 
 **Internal**
 
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     es_ES: `**Cambios de versión**
 
 - File Browser → 2.63.3
@@ -29,7 +29,7 @@ export const v_2_63_3_0 = VersionInfo.of({
 
 **Interno**
 
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     de_DE: `**Aktualisierungen**
 
 - File Browser → 2.63.3
@@ -41,7 +41,7 @@ export const v_2_63_3_0 = VersionInfo.of({
 
 **Intern**
 
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     pl_PL: `**Aktualizacje**
 
 - File Browser → 2.63.3
@@ -53,7 +53,7 @@ export const v_2_63_3_0 = VersionInfo.of({
 
 **Wewnętrzne**
 
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
     fr_FR: `**Mises à niveau**
 
 - File Browser → 2.63.3
@@ -65,7 +65,7 @@ export const v_2_63_3_0 = VersionInfo.of({
 
 **Interne**
 
-- start-sdk → 1.5.0`,
+- start-sdk → 1.5.2`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/v2.63.4.0.ts
+++ b/startos/versions/v2.63.4.0.ts
@@ -3,69 +3,14 @@ import { execFile } from 'child_process'
 import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
-export const v_2_63_3_0 = VersionInfo.of({
-  version: '2.63.3:0',
+export const v_2_63_4_0 = VersionInfo.of({
+  version: '2.63.4:0',
   releaseNotes: {
-    en_US: `**Bumps**
-
-- File Browser → 2.63.3
-
-**Fixes**
-
-- Conflict modal and resume-transfer option in the upload flow
-- Arrow keys now seek video in the preview instead of switching files
-
-**Internal**
-
-- start-sdk → 1.5.2`,
-    es_ES: `**Cambios de versión**
-
-- File Browser → 2.63.3
-
-**Correcciones**
-
-- Modal de conflicto y opción de reanudar transferencia en la carga
-- Las teclas de flecha ahora avanzan el vídeo en la vista previa en lugar de cambiar de archivo
-
-**Interno**
-
-- start-sdk → 1.5.2`,
-    de_DE: `**Aktualisierungen**
-
-- File Browser → 2.63.3
-
-**Fehlerbehebungen**
-
-- Konflikt-Dialog und Option zum Fortsetzen der Übertragung beim Hochladen
-- Pfeiltasten spulen in der Videovorschau, statt zwischen Dateien zu wechseln
-
-**Intern**
-
-- start-sdk → 1.5.2`,
-    pl_PL: `**Aktualizacje**
-
-- File Browser → 2.63.3
-
-**Poprawki**
-
-- Okno konfliktu i opcja wznowienia transferu w procesie wysyłania
-- Klawisze strzałek przewijają wideo w podglądzie zamiast przełączać pliki
-
-**Wewnętrzne**
-
-- start-sdk → 1.5.2`,
-    fr_FR: `**Mises à niveau**
-
-- File Browser → 2.63.3
-
-**Corrections**
-
-- Fenêtre de conflit et option de reprise de transfert lors de l'envoi
-- Les touches fléchées font défiler la vidéo dans l'aperçu au lieu de changer de fichier
-
-**Interne**
-
-- start-sdk → 1.5.2`,
+    en_US: 'Bumps File Browser → 2.63.4.',
+    es_ES: 'Actualiza File Browser → 2.63.4.',
+    de_DE: 'Aktualisiert File Browser → 2.63.4.',
+    pl_PL: 'Aktualizuje File Browser → 2.63.4.',
+    fr_FR: 'Met à niveau File Browser → 2.63.4.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- **SDK:** `@start9labs/start-sdk` 1.5.1 → 1.5.2. Passive bump — 1.5.2's only change fixes `Backups.withPgDump` / `Backups.withMysqlDump` writing empty dump files through the FUSE backup mount. This package's backups use `Backups.ofVolumes('data', 'database', 'config')` only, so the fix doesn't apply and no adaptations are needed.
- **Upstream:** File Browser is at v2.63.3 — latest upstream release (published 2026-05-05). No bump.
- **Release notes:** Updated the `**Internal**` line in `startos/versions/v2.63.3.0.ts` across all five locales to reflect the SDK version actually shipping in 2.63.3:0.

## Test plan

- [x] `make` produces `filebrowser_x86_64.s9pk` and `filebrowser_aarch64.s9pk` cleanly (SDK 1.5.2, version `2.63.3:0`)
- [ ] Install / fresh run on a StartOS host
- [ ] Upgrade from prior 0.4.0 release