### PR TITLE
fix: run File Browser as container-root

### DIFF
--- a/startos/actions/resetAdminUser.ts
+++ b/startos/actions/resetAdminUser.ts
@@ -26,19 +26,22 @@ export const resetAdminUser = sdk.Action.withoutInput(
       mounts,
       'setadmin',
       async (sub) => {
-        await sub.execFail([
-          'filebrowser',
-          '-c',
-          '/config/settings.json',
-          'users',
-          'update',
-          '1',
-          '-u',
-          adminUsername,
-          '-p',
-          password,
-          '--perm.admin',
-        ])
+        await sub.execFail(
+          [
+            'filebrowser',
+            '-c',
+            '/config/settings.json',
+            'users',
+            'update',
+            '1',
+            '-u',
+            adminUsername,
+            '-p',
+            password,
+            '--perm.admin',
+          ],
+          { user: 'root' },
+        )
       },
     )
 

--- a/startos/init/setup.ts
+++ b/startos/init/setup.ts
@@ -12,26 +12,22 @@ export const setup = sdk.setupOnInit(async (effects, kind) => {
       'set-admin',
       async (sub) => {
         await sub.execFail(
-          ['chown', '-R', 'user:user', '/srv', '/database', '/config'],
+          ['filebrowser', '-c', '/config/settings.json', 'config', 'init'],
           { user: 'root' },
         )
-        await sub.execFail([
-          'filebrowser',
-          '-c',
-          '/config/settings.json',
-          'config',
-          'init',
-        ])
-        await sub.execFail([
-          'filebrowser',
-          '-c',
-          '/config/settings.json',
-          'users',
-          'add',
-          'admin',
-          'taxationistheft',
-          '--perm.admin',
-        ])
+        await sub.execFail(
+          [
+            'filebrowser',
+            '-c',
+            '/config/settings.json',
+            'users',
+            'add',
+            'admin',
+            'taxationistheft',
+            '--perm.admin',
+          ],
+          { user: 'root' },
+        )
       },
     )
 

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -24,30 +24,21 @@ export const main = sdk.setupMain(async ({ effects }) => {
     'filebrowser-sub',
   )
 
-  return sdk.Daemons.of(effects)
-    .addOneshot('chown', {
-      subcontainer,
-      exec: {
-        command: ['chown', '-R', 'user:user', '/srv', '/database', '/config'],
-        user: 'root',
-      },
-      requires: [],
-    })
-    .addDaemon('primary', {
-      subcontainer,
-      exec: { command: sdk.useEntrypoint() },
-      ready: {
-        display: i18n('Web Interface'),
-        fn: () =>
-          sdk.healthCheck.checkWebUrl(
-            effects,
-            `http://localhost:${uiPort}/health`,
-            {
-              successMessage: i18n('The web interface is ready'),
-              errorMessage: i18n('The web interface is not ready'),
-            },
-          ),
-      },
-      requires: ['chown'],
-    })
+  return sdk.Daemons.of(effects).addDaemon('primary', {
+    subcontainer,
+    exec: { command: sdk.useEntrypoint(), user: 'root' },
+    ready: {
+      display: i18n('Web Interface'),
+      fn: () =>
+        sdk.healthCheck.checkWebUrl(
+          effects,
+          `http://localhost:${uiPort}/health`,
+          {
+            successMessage: i18n('The web interface is ready'),
+            errorMessage: i18n('The web interface is not ready'),
+          },
+        ),
+    },
+    requires: [],
+  })
 })

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_2_63_4_0 } from './v2.63.4.0'
+import { v_2_63_4_1 } from './v2.63.4.1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2_63_4_0,
-  other: [],
+  current: v_2_63_4_1,
+  other: [v_2_63_4_0],
 })

--- a/startos/versions/v2.63.4.1.ts
+++ b/startos/versions/v2.63.4.1.ts
@@ -1,0 +1,42 @@
+import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
+import { sdk } from '../sdk'
+import { mounts } from '../utils'
+
+export const v_2_63_4_1 = VersionInfo.of({
+  version: '2.63.4:1',
+  releaseNotes: {
+    en_US: `**Internal**
+
+- Run File Browser as container-root so dependent services can read files via owner permissions.
+- Migrate existing user-owned files in local volumes to root ownership.`,
+  },
+  migrations: {
+    up: async ({ effects }) => {
+      // File Browser now runs as container-root. Anything previously written
+      // by the non-root 'user' (UID 1000) needs to be reassigned so that the
+      // new root-owned daemon — and any sibling subcontainer reading via
+      // mountDependency — sees consistent ownership.
+      //
+      // -xdev stops `find` at filesystem boundaries, so any user-mounted
+      // network storage under /srv (NFS, SMB, etc.) is intentionally
+      // untouched. Those need to be fixed on the storage server.
+      await sdk.SubContainer.withTemp(
+        effects,
+        { imageId: 'filebrowser' },
+        mounts,
+        'migrate-perms',
+        async (sub) => {
+          await sub.execFail(
+            [
+              'sh',
+              '-c',
+              'find /srv /database /config -xdev -exec chown root:root {} + || true',
+            ],
+            { user: 'root' },
+          )
+        },
+      )
+    },
+    down: IMPOSSIBLE,
+  },
+})


### PR DESCRIPTION
## Summary

- Run the primary File Browser daemon as `root` instead of UID 1000 (`user`), so dependent services reading via `mountDependency` can access File Browser–written files through owner permissions.
- Drop the `chown -R user:user` oneshot from `main.ts` and the matching `chown` step in `init/setup.ts`; the init-time admin bootstrap and the `resetAdminUser` action now `execFail` with `{ user: 'root' }`.
- Bump to `2.63.4:1` with an `up` migration that re-`chown`s existing `/srv /database /config` contents from `user:user` to `root:root`. `find -xdev` keeps the migration on local volumes — user-mounted network storage (NFS, SMB) is intentionally skipped and must be fixed at the storage server.
- `down: IMPOSSIBLE` — no reverse path once data is rewritten.

## Test plan

- [X] Fresh install on `2.63.4:1`: web UI reaches Ready, admin login (`admin` / `taxationistheft`) works, uploaded files land owned by root.
- [X] Upgrade from `2.63.4:0` with pre-existing `user:user` files in `/srv`, `/database`, `/config`: migration runs, files end up `root:root`, service starts cleanly.
- [X] `resetAdminUser` action succeeds end-to-end and the new password works.
- [X] A dependent service using `mountDependency` against File Browser volumes can now read the mounted files.

Note: There is an existing [upstream bug](https://github.com/filebrowser/filebrowser/issues/5951) that prevents logging in on the root path. Until an upstream fix is available appending /login is a viable workaround.