### PR TITLE
chore: bump File Browser to 2.63.5; bump start-sdk to 1.5.3; 2.63.4:0 → 2.63.5:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "filebrowser-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.2"
+        "@start9labs/start-sdk": "1.5.3"
       },
       "devDependencies": {
         "@types/node": "^22.19.3",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
-      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.3.tgz",
+      "integrity": "sha512-OyHe9J6hMvyA5ZavcLkxdVQvZcuTH9J9kagV6NDI83eAG/YpJFIq62gP/n/2PPNdHWwNSXVQmSwnsvsV8Gyg+A==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.2"
+    "@start9labs/start-sdk": "1.5.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.4',
+        dockerTag: 'filebrowser/filebrowser:v2.63.5',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_2_63_4_0 } from './v2.63.4.0'
+import { v_2_63_5_0 } from './v2.63.5.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2_63_4_0,
+  current: v_2_63_5_0,
   other: [],
 })

--- a/startos/versions/v2.63.5.0.ts
+++ b/startos/versions/v2.63.5.0.ts
@@ -3,14 +3,14 @@ import { execFile } from 'child_process'
 import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
-export const v_2_63_4_0 = VersionInfo.of({
-  version: '2.63.4:0',
+export const v_2_63_5_0 = VersionInfo.of({
+  version: '2.63.5:0',
   releaseNotes: {
-    en_US: 'Bumps File Browser → 2.63.4.',
-    es_ES: 'Actualiza File Browser → 2.63.4.',
-    de_DE: 'Aktualisiert File Browser → 2.63.4.',
-    pl_PL: 'Aktualizuje File Browser → 2.63.4.',
-    fr_FR: 'Met à niveau File Browser → 2.63.4.',
+    en_US: 'Bumps File Browser → 2.63.5.',
+    es_ES: 'Actualiza File Browser → 2.63.5.',
+    de_DE: 'Aktualisiert File Browser → 2.63.5.',
+    pl_PL: 'Aktualizuje File Browser → 2.63.5.',
+    fr_FR: 'Met à niveau File Browser → 2.63.5.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps File Browser to **2.63.5** (upstream patch release — fixes a router crash on undefined `catchAll` param on root redirect, [filebrowser/filebrowser#5955](https://github.com/filebrowser/filebrowser/pull/5955)).
- Bumps `@start9labs/start-sdk` 1.5.2 → 1.5.3.
- StartOS version: `2.63.4:0` → `2.63.5:0`. Version file renamed in place (no migration carried by this bump; the existing pre-2.63.4 layout migration moves with the file).

## Test plan

- [x] `make` produces clean `filebrowser_x86_64.s9pk` and `filebrowser_aarch64.s9pk` at `v2.63.5:0` / SDK `1.5.3`.
- [x] Fresh install of `filebrowser_x86_64.s9pk` on a StartOS test VM via `start-cli package install --sideload`; service starts, listens on `[::]:8080`, no errors in logs.