### PR TITLE
chore: bump File Browser to 2.63.9; 2.63.5:0 → 2.63.9:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.5',
+        dockerTag: 'filebrowser/filebrowser:v2.63.9',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,13 +4,13 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.5:0',
+  version: '2.63.9:0',
   releaseNotes: {
-    en_US: 'Bumps File Browser → 2.63.5.',
-    es_ES: 'Actualiza File Browser → 2.63.5.',
-    de_DE: 'Aktualisiert File Browser → 2.63.5.',
-    pl_PL: 'Aktualizuje File Browser → 2.63.5.',
-    fr_FR: 'Met à niveau File Browser → 2.63.5.',
+    en_US: 'Bumps File Browser → 2.63.9.',
+    es_ES: 'Actualiza File Browser → 2.63.9.',
+    de_DE: 'Aktualisiert File Browser → 2.63.9.',
+    pl_PL: 'Aktualizuje File Browser → 2.63.9.',
+    fr_FR: 'Met à niveau File Browser → 2.63.9.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps **File Browser** `v2.63.5` → `v2.63.9` (Docker tag in `startos/manifest/index.ts`), and sets the StartOS version to `2.63.9:0` in `startos/versions/current.ts`.

These are upstream **patch** releases — bug and security fixes only, no breaking changes:

- **2.63.6** — security disclosures (archive traversal, login DoS, symlink escape), cross-user share-link deletion fix, public-share access-control fix, CSV parsing fix, removed undocumented hook auth.
- **2.63.7** — disallow shares for non-existent paths.
- **2.63.8** — verify share is within scope on creation.
- **2.63.9** — `X-Content-Type-Options: nosniff` on raw responses, constant-time share-token comparison, symlink scope-escape fix for copy/move/rename, force octet-stream for attachment downloads.

No migration required — the existing migration on the current version node is carried forward unchanged.

`@start9labs/start-sdk` is already at the latest published version (`1.5.3`); `npm update` only refreshed a transitive sub-dependency (`@nodable/entities` 2.1.0 → 2.1.1).

## Test plan

- [x] `npm run check` (tsc typecheck) passes on `2.63.9:0`.