### PR TITLE
chore: bump File Browser to 2.63.11; 2.63.9:0 → 2.63.11:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.9',
+        dockerTag: 'filebrowser/filebrowser:v2.63.11',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,13 +4,13 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.9:0',
+  version: '2.63.11:0',
   releaseNotes: {
-    en_US: 'Bumps File Browser → 2.63.9.',
-    es_ES: 'Actualiza File Browser → 2.63.9.',
-    de_DE: 'Aktualisiert File Browser → 2.63.9.',
-    pl_PL: 'Aktualizuje File Browser → 2.63.9.',
-    fr_FR: 'Met à niveau File Browser → 2.63.9.',
+    en_US: 'Bumps File Browser → 2.63.11.',
+    es_ES: 'Actualiza File Browser → 2.63.11.',
+    de_DE: 'Aktualisiert File Browser → 2.63.11.',
+    pl_PL: 'Aktualizuje File Browser → 2.63.11.',
+    fr_FR: 'Met à niveau File Browser → 2.63.11.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the wrapped **File Browser** image from `v2.63.9` to `v2.63.11`.

- `startos/manifest/index.ts`: `dockerTag` → `filebrowser/filebrowser:v2.63.11`
- `startos/versions/current.ts`: `version` → `2.63.11:0`, release notes updated in all locales

Both upstream releases are patch-level security/bug fixes:

- **2.63.10** — fix: allow writes when user scope resolves to filesystem root
- **2.63.11** — fix: incomplete fix for symlinked directories let scoped users and public-share recipients read/write files outside of scope

No breaking changes; no migration required (the existing 0351 migration on `current` is carried forward untouched). `@start9labs/start-sdk` already pinned at the latest `1.5.3`.

## Test plan

- [x] `npm run check` (tsc typecheck) passes on `2.63.11:0`
- [ ] `make` build verified in review