### PR TITLE
chore: bump File Browser to 2.63.12; 2.63.11:0 → 2.63.12:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.12',
+        dockerTag: 'filebrowser/filebrowser:v2.63.13',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.11',
+        dockerTag: 'filebrowser/filebrowser:v2.63.12',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,13 +4,13 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.12:0',
+  version: '2.63.13:0',
   releaseNotes: {
-    en_US: 'Bumps File Browser → 2.63.12.',
-    es_ES: 'Actualiza File Browser → 2.63.12.',
-    de_DE: 'Aktualisiert File Browser → 2.63.12.',
-    pl_PL: 'Aktualizuje File Browser → 2.63.12.',
-    fr_FR: 'Met à niveau File Browser → 2.63.12.',
+    en_US: 'Bumps File Browser → 2.63.13.',
+    es_ES: 'Actualiza File Browser → 2.63.13.',
+    de_DE: 'Aktualisiert File Browser → 2.63.13.',
+    pl_PL: 'Aktualizuje File Browser → 2.63.13.',
+    fr_FR: 'Met à niveau File Browser → 2.63.13.',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,13 +4,13 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.11:0',
+  version: '2.63.12:0',
   releaseNotes: {
-    en_US: 'Bumps File Browser → 2.63.11.',
-    es_ES: 'Actualiza File Browser → 2.63.11.',
-    de_DE: 'Aktualisiert File Browser → 2.63.11.',
-    pl_PL: 'Aktualizuje File Browser → 2.63.11.',
-    fr_FR: 'Met à niveau File Browser → 2.63.11.',
+    en_US: 'Bumps File Browser → 2.63.12.',
+    es_ES: 'Actualiza File Browser → 2.63.12.',
+    de_DE: 'Aktualisiert File Browser → 2.63.12.',
+    pl_PL: 'Aktualizuje File Browser → 2.63.12.',
+    fr_FR: 'Met à niveau File Browser → 2.63.12.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the wrapped **File Browser** image from `v2.63.11` to `v2.63.12` (upstream patch release).

- `startos/manifest/index.ts`: `images.filebrowser.source.dockerTag` → `filebrowser/filebrowser:v2.63.12`
- `startos/versions/current.ts`: `version` → `2.63.12:0`, release notes updated in all locales (edited in place; the existing 0351 migration is carried forward unchanged)

`@start9labs/start-sdk` is already at the latest npm version (1.5.3); `npm update` produced no lockfile changes.

## Upstream changelog (2.63.11 → 2.63.12)

- fix: await copy move conflict detection (#5978)
- fix: keep mobile file sort controls visible (#5977)
- fix: skip inaccessible children when listing directories (#5958)

Patch-level fixes only — no user-visible config/action/interface changes, so README and instructions need no edits.

## Test plan

- [x] `npm run check` (tsc --noEmit) green