### PR TITLE
chore: bump File Browser to 2.63.14; 2.63.13:0 → 2.63.14:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
       "funding": [
         {
           "type": "github",
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
@@ -270,7 +270,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
-      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -105,6 +105,18 @@
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
@@ -231,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -247,16 +259,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.15',
+        dockerTag: 'filebrowser/filebrowser:v2.63.16',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.14',
+        dockerTag: 'filebrowser/filebrowser:v2.63.15',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.13',
+        dockerTag: 'filebrowser/filebrowser:v2.63.14',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,18 +4,18 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.15:0',
+  version: '2.63.16:0',
   releaseNotes: {
     en_US:
-      'Updated File Browser to 2.63.15. Maintenance release: restores ScopedFs RealPath behavior and bumps minor Go dependencies. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
+      'Updated File Browser to 2.63.16. Maintenance release: makes external symlink following opt-in via followExternalSymlinks and fixes dangling-symlink, write, and delete scope bugs. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
     es_ES:
-      'Actualiza File Browser a 2.63.15. Versión de mantenimiento: restaura el comportamiento de RealPath de ScopedFs y actualiza dependencias menores de Go. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
+      'Actualiza File Browser a 2.63.16. Versión de mantenimiento: el seguimiento de enlaces simbólicos externos ahora es opcional mediante followExternalSymlinks y corrige errores de enlaces simbólicos colgantes, de escritura y de alcance de eliminación. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
     de_DE:
-      'Aktualisiert File Browser auf 2.63.15. Wartungsversion: stellt das RealPath-Verhalten von ScopedFs wieder her und aktualisiert kleinere Go-Abhängigkeiten. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
+      'Aktualisiert File Browser auf 2.63.16. Wartungsversion: das Folgen externer Symlinks ist nun über followExternalSymlinks optional und behebt Fehler bei verwaisten Symlinks sowie beim Schreib- und Löschbereich. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
     pl_PL:
-      'Aktualizuje File Browser do 2.63.15. Wydanie konserwacyjne: przywraca zachowanie RealPath w ScopedFs i aktualizuje pomniejsze zależności Go. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
+      'Aktualizuje File Browser do 2.63.16. Wydanie konserwacyjne: podążanie za zewnętrznymi dowiązaniami symbolicznymi jest teraz opcjonalne poprzez followExternalSymlinks oraz naprawia błędy wiszących dowiązań symbolicznych, zapisu i zakresu usuwania. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
     fr_FR:
-      'Met à niveau File Browser vers 2.63.15. Version de maintenance : restaure le comportement RealPath de ScopedFs et met à jour des dépendances Go mineures. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
+      'Met à niveau File Browser vers 2.63.16. Version de maintenance : le suivi des liens symboliques externes devient optionnel via followExternalSymlinks et corrige des bugs de liens symboliques orphelins, d’écriture et de portée de suppression. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,18 +4,18 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.14:0',
+  version: '2.63.15:0',
   releaseNotes: {
     en_US:
-      'Updated File Browser to 2.63.14. Hardens the scoped filesystem so symlinks can no longer escape the configured scope, plus a recursive-check fix. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+      'Updated File Browser to 2.63.15. Maintenance release: restores ScopedFs RealPath behavior and bumps minor Go dependencies. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
     es_ES:
-      'Actualiza File Browser a 2.63.14. Refuerza el sistema de archivos restringido para que los enlaces simbólicos ya no puedan salir del ámbito configurado, además de una corrección en la comprobación recursiva. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+      'Actualiza File Browser a 2.63.15. Versión de mantenimiento: restaura el comportamiento de RealPath de ScopedFs y actualiza dependencias menores de Go. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
     de_DE:
-      'Aktualisiert File Browser auf 2.63.14. Härtet das eingeschränkte Dateisystem ab, sodass symbolische Links den konfigurierten Bereich nicht mehr verlassen können, sowie eine Korrektur der rekursiven Prüfung. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+      'Aktualisiert File Browser auf 2.63.15. Wartungsversion: stellt das RealPath-Verhalten von ScopedFs wieder her und aktualisiert kleinere Go-Abhängigkeiten. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
     pl_PL:
-      'Aktualizuje File Browser do 2.63.14. Wzmacnia ograniczony system plików, aby dowiązania symboliczne nie mogły już wychodzić poza skonfigurowany zakres, oraz poprawka kontroli rekurencyjnej. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+      'Aktualizuje File Browser do 2.63.15. Wydanie konserwacyjne: przywraca zachowanie RealPath w ScopedFs i aktualizuje pomniejsze zależności Go. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
     fr_FR:
-      'Met à niveau File Browser vers 2.63.14. Renforce le système de fichiers restreint afin que les liens symboliques ne puissent plus sortir de la portée configurée, ainsi qu’un correctif de la vérification récursive. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+      'Met à niveau File Browser vers 2.63.15. Version de maintenance : restaure le comportement RealPath de ScopedFs et met à jour des dépendances Go mineures. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.15',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,13 +4,18 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.13:0',
+  version: '2.63.14:0',
   releaseNotes: {
-    en_US: 'Bumps File Browser → 2.63.13.',
-    es_ES: 'Actualiza File Browser → 2.63.13.',
-    de_DE: 'Aktualisiert File Browser → 2.63.13.',
-    pl_PL: 'Aktualizuje File Browser → 2.63.13.',
-    fr_FR: 'Met à niveau File Browser → 2.63.13.',
+    en_US:
+      'Updated File Browser to 2.63.14. Hardens the scoped filesystem so symlinks can no longer escape the configured scope, plus a recursive-check fix. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+    es_ES:
+      'Actualiza File Browser a 2.63.14. Refuerza el sistema de archivos restringido para que los enlaces simbólicos ya no puedan salir del ámbito configurado, además de una corrección en la comprobación recursiva. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+    de_DE:
+      'Aktualisiert File Browser auf 2.63.14. Härtet das eingeschränkte Dateisystem ab, sodass symbolische Links den konfigurierten Bereich nicht mehr verlassen können, sowie eine Korrektur der rekursiven Prüfung. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+    pl_PL:
+      'Aktualizuje File Browser do 2.63.14. Wzmacnia ograniczony system plików, aby dowiązania symboliczne nie mogły już wychodzić poza skonfigurowany zakres, oraz poprawka kontroli rekurencyjnej. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
+    fr_FR:
+      'Met à niveau File Browser vers 2.63.14. Renforce le système de fichiers restreint afin que les liens symboliques ne puissent plus sortir de la portée configurée, ainsi qu’un correctif de la vérification récursive. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Monitor-cycle upstream bump for **File Browser**.

- **Upstream:** File Browser `v2.63.13` → `v2.63.14` (`startos/manifest/index.ts` dockerTag, verified published on Docker Hub).
- **StartOS version:** `2.63.13:0` → `2.63.14:0` (edited `current.ts` in place; no new migration — the existing 0351 migration is carried forward unchanged).
- **start-sdk:** already at latest `1.5.3`, no bump. `npm update` produced no lockfile changes.

### What changed upstream

Patch release. Notable change is a security hardening of the scoped filesystem (`ScopedFs`) so symlinks can no longer escape the configured scope, plus a recursive-check fix. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.14

## Test plan

- `npm run check` (tsc --noEmit) — green.
- `make` / s9pk pack — deferred to PR review per monitor-cycle policy.