### PR TITLE
chore: bump File Browser to 2.63.17; 2.63.16:0 → 2.63.17:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.0.tgz",
+      "integrity": "sha512-LjIqSIC5VYLzs9WedVmJ2ljNAGnU+DteIClbahu4L/DBeWjZ6iT/k1lAYyu9JUh+1xINxWadaPw/Pl63y/agAw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.16',
+        dockerTag: 'filebrowser/filebrowser:v2.63.17',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -4,18 +4,18 @@ import * as fs from 'fs/promises'
 import { settingsJson } from '../fileModels/settings.json'
 
 export const current = VersionInfo.of({
-  version: '2.63.16:0',
+  version: '2.63.17:0',
   releaseNotes: {
     en_US:
-      'Updated File Browser to 2.63.16. Maintenance release: makes external symlink following opt-in via followExternalSymlinks and fixes dangling-symlink, write, and delete scope bugs. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
+      'Updated File Browser to 2.63.17. Security release: patches several share, auth, and archive vulnerabilities (stops leaking share password hashes and bypass tokens, fixes trailing-slash share deletion, rejects colliding self-signup home dirs, neutralizes backslashes in archive entry names) plus minor fixes. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.17',
     es_ES:
-      'Actualiza File Browser a 2.63.16. Versión de mantenimiento: el seguimiento de enlaces simbólicos externos ahora es opcional mediante followExternalSymlinks y corrige errores de enlaces simbólicos colgantes, de escritura y de alcance de eliminación. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
+      'Actualiza File Browser a 2.63.17. Versión de seguridad: corrige varias vulnerabilidades de compartición, autenticación y archivos comprimidos (deja de filtrar hashes de contraseñas y tokens de elusión de comparticiones, corrige el borrado de comparticiones con barra final, rechaza directorios de inicio en conflicto en el autorregistro y neutraliza las barras invertidas en los nombres de entradas de archivos) además de correcciones menores. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.17',
     de_DE:
-      'Aktualisiert File Browser auf 2.63.16. Wartungsversion: das Folgen externer Symlinks ist nun über followExternalSymlinks optional und behebt Fehler bei verwaisten Symlinks sowie beim Schreib- und Löschbereich. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
+      'Aktualisiert File Browser auf 2.63.17. Sicherheitsversion: behebt mehrere Schwachstellen bei Freigaben, Authentifizierung und Archiven (kein Leaken von Freigabe-Passwort-Hashes und Bypass-Tokens mehr, korrigiert das Löschen von Freigaben mit abschließendem Schrägstrich, lehnt kollidierende Home-Verzeichnisse bei Selbstregistrierung ab und neutralisiert Backslashes in Archiv-Eintragsnamen) sowie kleinere Korrekturen. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.17',
     pl_PL:
-      'Aktualizuje File Browser do 2.63.16. Wydanie konserwacyjne: podążanie za zewnętrznymi dowiązaniami symbolicznymi jest teraz opcjonalne poprzez followExternalSymlinks oraz naprawia błędy wiszących dowiązań symbolicznych, zapisu i zakresu usuwania. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
+      'Aktualizuje File Browser do 2.63.17. Wydanie zabezpieczeń: łata kilka luk w udostępnianiu, uwierzytelnianiu i archiwach (przestaje ujawniać skróty haseł i tokeny obejścia udostępnień, naprawia usuwanie udostępnień z końcowym ukośnikiem, odrzuca kolidujące katalogi domowe przy samodzielnej rejestracji i neutralizuje ukośniki wsteczne w nazwach wpisów archiwów) oraz drobne poprawki. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.17',
     fr_FR:
-      'Met à niveau File Browser vers 2.63.16. Version de maintenance : le suivi des liens symboliques externes devient optionnel via followExternalSymlinks et corrige des bugs de liens symboliques orphelins, d’écriture et de portée de suppression. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.16',
+      'Met à niveau File Browser vers 2.63.17. Version de sécurité : corrige plusieurs vulnérabilités de partage, d’authentification et d’archives (ne divulgue plus les hachages de mots de passe et les jetons de contournement des partages, corrige la suppression des partages avec barre oblique finale, rejette les répertoires personnels en conflit lors de l’auto-inscription et neutralise les barres obliques inverses dans les noms d’entrées d’archives) ainsi que des corrections mineures. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.17',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps File Browser to **2.63.17** (StartOS `2.63.16:0` → `2.63.17:0`).

This is an upstream **security** release. Changes:

- Stops exposing share password hashes and bypass tokens in the share API (GHSA-833g-cqhp-h72j)
- Fixes deletion of the exact directory share on trailing-slash delete (GHSA-pp88-jhwj-5qh5)
- Rejects self-signup when the normalized home dir collides (GHSA-7rc3-g7h6-22m7)
- Neutralizes backslashes in archive entry names (GHSA-83xp-526h-j3ww)
- Warns about broad scope for self-signup users (GHSA-6759-996p-gpj6)
- Minor fixes: admin share path matching by owner scope, recursive listing path normalization, SRT subtitle line-break preservation, translation updates

Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.17

## Changes

- `startos/manifest/index.ts`: dockerTag → `filebrowser/filebrowser:v2.63.17`
- `startos/versions/current.ts`: version → `2.63.17:0` + release notes (all locales)
- `npm update` (lockfile)

start-sdk already at latest (1.5.3) — no SDK bump. No breaking changes; the carried-forward `0351` migration is unchanged.

## Test plan

- [x] `npm run check` (tsc) passes