### PR TITLE
chore: bump File Browser to 2.63.23; 2.63.18:4 → 2.63.23:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   images: {
     filebrowser: {
       source: {
-        dockerTag: 'filebrowser/filebrowser:v2.63.18',
+        dockerTag: 'filebrowser/filebrowser:v2.63.23',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,48 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2.63.18:4',
+  version: '2.63.23:0',
   releaseNotes: {
-    en_US:
-      'Updated File Browser to 2.63.18. Minor maintenance release: fixes recursive conflict checks when copying and moving files, keeps the EPUB preview table-of-contents button clear of the header, and refreshes translations and dependencies. Full notes: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18',
-    es_ES:
-      'Actualiza File Browser a 2.63.18. Versión de mantenimiento menor: corrige las comprobaciones recursivas de conflictos al copiar y mover archivos, mantiene el botón del índice de la vista previa de EPUB apartado del encabezado y actualiza las traducciones y las dependencias. Notas completas: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18',
-    de_DE:
-      'Aktualisiert File Browser auf 2.63.18. Kleine Wartungsversion: behebt rekursive Konfliktprüfungen beim Kopieren und Verschieben von Dateien, hält die Inhaltsverzeichnis-Schaltfläche der EPUB-Vorschau vom Kopfbereich frei und aktualisiert Übersetzungen und Abhängigkeiten. Vollständige Hinweise: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18',
-    pl_PL:
-      'Aktualizuje File Browser do 2.63.18. Drobne wydanie konserwacyjne: naprawia rekurencyjne sprawdzanie konfliktów podczas kopiowania i przenoszenia plików, utrzymuje przycisk spisu treści w podglądzie EPUB z dala od nagłówka oraz odświeża tłumaczenia i zależności. Pełne informacje: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18',
-    fr_FR:
-      'Met à niveau File Browser vers 2.63.18. Version de maintenance mineure : corrige les vérifications récursives de conflits lors de la copie et du déplacement de fichiers, maintient le bouton de la table des matières de l’aperçu EPUB à l’écart de l’en-tête et met à jour les traductions et les dépendances. Notes complètes : https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18',
+    en_US: `Updated File Browser to 2.63.23.
+
+- Tightens access control: permission rules are now enforced on recursive operations, expired proxy tokens, and file checksum requests, and paths are canonicalized before rules are checked.
+- Confines auto-provisioned proxy and hook users to their own home directory.
+- Fixes stalled and frozen uploads, and makes the sidebar scrollable when its content overflows.
+- Upstream has announced that File Browser is winding down: 2.63.23 is the last planned release, and the project repository will be archived on 2026-09-01. Existing releases and images remain available.
+
+Full notes: https://github.com/filebrowser/filebrowser/compare/v2.63.18...v2.63.23`,
+    es_ES: `Actualiza File Browser a 2.63.23.
+
+- Refuerza el control de acceso: ahora las reglas de permisos se aplican en las operaciones recursivas, los tokens de proxy caducados y las solicitudes de suma de verificación, y las rutas se canonizan antes de comprobar las reglas.
+- Limita los usuarios de proxy y de hooks aprovisionados automáticamente a su propio directorio personal.
+- Corrige las cargas detenidas y bloqueadas, y permite desplazar la barra lateral cuando su contenido se desborda.
+- El proyecto original ha anunciado que File Browser se está retirando: 2.63.23 es la última versión prevista y el repositorio se archivará el 2026-09-01. Las versiones e imágenes existentes seguirán disponibles.
+
+Notas completas: https://github.com/filebrowser/filebrowser/compare/v2.63.18...v2.63.23`,
+    de_DE: `Aktualisiert File Browser auf 2.63.23.
+
+- Verschärft die Zugriffskontrolle: Berechtigungsregeln gelten nun auch für rekursive Vorgänge, abgelaufene Proxy-Token und Prüfsummenanfragen, und Pfade werden vor der Regelprüfung kanonisiert.
+- Beschränkt automatisch bereitgestellte Proxy- und Hook-Benutzer auf ihr eigenes Home-Verzeichnis.
+- Behebt hängende und eingefrorene Uploads und macht die Seitenleiste scrollbar, wenn ihr Inhalt überläuft.
+- Das Upstream-Projekt hat angekündigt, dass File Browser eingestellt wird: 2.63.23 ist die letzte geplante Version und das Repository wird am 2026-09-01 archiviert. Bestehende Versionen und Images bleiben verfügbar.
+
+Vollständige Hinweise: https://github.com/filebrowser/filebrowser/compare/v2.63.18...v2.63.23`,
+    pl_PL: `Aktualizuje File Browser do 2.63.23.
+
+- Wzmacnia kontrolę dostępu: reguły uprawnień są teraz egzekwowane przy operacjach rekurencyjnych, wygasłych tokenach proxy i żądaniach sumy kontrolnej, a ścieżki są kanonizowane przed sprawdzeniem reguł.
+- Ogranicza automatycznie tworzonych użytkowników proxy i hooków do ich własnego katalogu domowego.
+- Naprawia zatrzymane i zamrożone przesyłanie plików oraz umożliwia przewijanie paska bocznego, gdy jego zawartość się nie mieści.
+- Twórcy ogłosili wygaszanie projektu File Browser: 2.63.23 to ostatnie planowane wydanie, a repozytorium zostanie zarchiwizowane 2026-09-01. Dotychczasowe wydania i obrazy pozostaną dostępne.
+
+Pełne informacje: https://github.com/filebrowser/filebrowser/compare/v2.63.18...v2.63.23`,
+    fr_FR: `Met à niveau File Browser vers 2.63.23.
+
+- Renforce le contrôle d'accès : les règles de permissions s'appliquent désormais aux opérations récursives, aux jetons de proxy expirés et aux demandes de somme de contrôle, et les chemins sont canonisés avant la vérification des règles.
+- Limite les utilisateurs de proxy et de hooks provisionnés automatiquement à leur propre répertoire personnel.
+- Corrige les téléversements bloqués et figés, et rend la barre latérale défilante lorsque son contenu déborde.
+- Le projet amont a annoncé l'arrêt progressif de File Browser : 2.63.23 est la dernière version prévue et le dépôt sera archivé le 2026-09-01. Les versions et images existantes restent disponibles.
+
+Notes complètes : https://github.com/filebrowser/filebrowser/compare/v2.63.18...v2.63.23`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps File Browser from **2.63.18** to **2.63.23** (`filebrowser/filebrowser:v2.63.23`), covering upstream releases 2.63.19 → 2.63.23. StartOS version `2.63.18:4` → `2.63.23:0`.

No SDK bump rode along — `@start9labs/start-sdk` is already pinned at `2.0.9`, which is the latest on npm. This package has no `*-startos` git dependencies, so the lockfile is untouched; the diff is the docker tag and `current.ts` only.

## Upstream highlights

Mostly hardening across the permission layer:

- Permission rules are now enforced on recursive operations, expired proxy tokens, and the file-checksum branch; paths are canonicalized *before* rules are checked (#6045, #6053).
- Auto-provisioned proxy and hook users are confined to their own home directory, and home-directory collisions that differ only by case are rejected.
- TUS uploads enforce the declared `Upload-Length`, and abandoned uploads are deleted through the scoped filesystem.
- Fixes stalled/frozen uploads, a non-scrollable sidebar on overflow, PWA manifest icon URLs, and a panic on an unreadable directory during copy.
- Security dependency bumps: `dompurify` 3.4.12, `postcss` 8.5.18.

Full range: https://github.com/filebrowser/filebrowser/compare/v2.63.18...v2.63.23

## Note for reviewers: upstream is winding down

Starting with 2.63.22, upstream carries a wind-down notice: **2.63.23 is the last planned release and the repository will be archived on 2026-09-01.** After that there will be no further releases, bug fixes, or security fixes. Existing releases and Docker images stay online and will not be withdrawn.

I've mentioned this in the release notes so users hear it from the StartOS UI rather than discovering it later. What it means for this package longer-term (pin and freeze, seek a maintained fork, or deprecate) is a product call I've deliberately left alone here.

## Verification

- `filebrowser/filebrowser:v2.63.23` confirmed published on Docker Hub (3 arch images, pushed 2026-07-27).
- Registry checked: latest published is `2.63.18:4`, so `2.63.23:0` is free.
- `npm run check` (tsc) green.

Per the monitor cycle, `make` / s9pk pack was not run — full build verification happens in review.
